### PR TITLE
Fix/report controller_re

### DIFF
--- a/src/main/java/com/gamyeon/report/infrastructure/web/ReportController.java
+++ b/src/main/java/com/gamyeon/report/infrastructure/web/ReportController.java
@@ -11,8 +11,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/report")
@@ -23,28 +23,30 @@ public class ReportController {
   private final GetReportDetailUseCase getReportDetailUseCase;
   private final DeleteReportUseCase deleteReportUseCase;
 
-  // [SECURITY TODO] JWT 도입 후 userId는 토큰에서 추출하도록 변경 필요
-
   @GetMapping("/list")
-  public ResponseEntity<ApiResponse<List<ReportListResponse>>> getList(@RequestParam Long userId) {
+  public ResponseEntity<ApiResponse<List<ReportListResponse>>> getList(
+          @AuthenticationPrincipal Long userId  // JWT 필터에서 세팅한 userId 직접 추출
+  ) {
     log.info("[Report] 목록 조회 - userId={}", userId);
     return ApiResponse.success(
-        ReportSuccessCode.REPORT_LIST_SUCCESS, getReportListUseCase.getList(userId));
+            ReportSuccessCode.REPORT_LIST_SUCCESS, getReportListUseCase.getList(userId));
   }
 
   @GetMapping("/detail/{intvId}")
   public ResponseEntity<ApiResponse<ReportDetailResponse>> getDetail(
-      @PathVariable Long intvId, Long userId) {
-    userId = 1L;
-
+          @PathVariable Long intvId,
+          @AuthenticationPrincipal Long userId  // userId = 1L 하드코딩 제거
+  ) {
     log.info("[Report] 상세 조회 - intvId={}, userId={}", intvId, userId);
     return ApiResponse.success(
-        ReportSuccessCode.REPORT_DETAIL_SUCCESS, getReportDetailUseCase.getDetail(intvId, userId));
+            ReportSuccessCode.REPORT_DETAIL_SUCCESS, getReportDetailUseCase.getDetail(intvId, userId));
   }
 
   @DeleteMapping("/{intvId}")
-  public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long intvId, Long userId) {
-    userId = 1L;
+  public ResponseEntity<ApiResponse<Void>> delete(
+          @PathVariable Long intvId,
+          @AuthenticationPrincipal Long userId  // userId = 1L 하드코딩 제거
+  ) {
     log.info("[Report] 삭제 - intvId={}, userId={}", intvId, userId);
     deleteReportUseCase.delete(intvId, userId);
     return ApiResponse.success(ReportSuccessCode.REPORT_DELETE_SUCCESS);

--- a/src/main/java/com/gamyeon/report/infrastructure/web/ReportController.java
+++ b/src/main/java/com/gamyeon/report/infrastructure/web/ReportController.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/report")
@@ -25,28 +26,26 @@ public class ReportController {
 
   @GetMapping("/list")
   public ResponseEntity<ApiResponse<List<ReportListResponse>>> getList(
-          @AuthenticationPrincipal Long userId  // JWT 필터에서 세팅한 userId 직접 추출
-  ) {
+      @AuthenticationPrincipal Long userId // JWT 필터에서 세팅한 userId 직접 추출
+      ) {
     log.info("[Report] 목록 조회 - userId={}", userId);
     return ApiResponse.success(
-            ReportSuccessCode.REPORT_LIST_SUCCESS, getReportListUseCase.getList(userId));
+        ReportSuccessCode.REPORT_LIST_SUCCESS, getReportListUseCase.getList(userId));
   }
 
   @GetMapping("/detail/{intvId}")
   public ResponseEntity<ApiResponse<ReportDetailResponse>> getDetail(
-          @PathVariable Long intvId,
-          @AuthenticationPrincipal Long userId  // userId = 1L 하드코딩 제거
-  ) {
+      @PathVariable Long intvId, @AuthenticationPrincipal Long userId // userId = 1L 하드코딩 제거
+      ) {
     log.info("[Report] 상세 조회 - intvId={}, userId={}", intvId, userId);
     return ApiResponse.success(
-            ReportSuccessCode.REPORT_DETAIL_SUCCESS, getReportDetailUseCase.getDetail(intvId, userId));
+        ReportSuccessCode.REPORT_DETAIL_SUCCESS, getReportDetailUseCase.getDetail(intvId, userId));
   }
 
   @DeleteMapping("/{intvId}")
   public ResponseEntity<ApiResponse<Void>> delete(
-          @PathVariable Long intvId,
-          @AuthenticationPrincipal Long userId  // userId = 1L 하드코딩 제거
-  ) {
+      @PathVariable Long intvId, @AuthenticationPrincipal Long userId // userId = 1L 하드코딩 제거
+      ) {
     log.info("[Report] 삭제 - intvId={}, userId={}", intvId, userId);
     deleteReportUseCase.delete(intvId, userId);
     return ApiResponse.success(ReportSuccessCode.REPORT_DELETE_SUCCESS);

--- a/src/test/resources/application-report.yml
+++ b/src/test/resources/application-report.yml
@@ -39,7 +39,6 @@ storage:
     bucket: test-bucket
     region: ap-northeast-2
     presigned-duration-seconds: 900
-    #  중요: 빈 값으로 두지 말고 아무 문자열이나 채워넣어야 SDK 에러가 안 납니다.
     access-key: dummy-access-key
     secret-key: dummy-secret-key
 


### PR DESCRIPTION

_기존 4번 PR 깃헙 시스템이 approve 무효화 시켜서 다시올립니다._ 

## 관련 이슈
closes #3 
보안이슈로 report Controller 하드코딩이 있었습니다. 

## 작업 내용
- 로그인 기능이 완성되면서, report Controller 부분 수정했습니다. 
- 리포트 목록조회(/api/v1/report/list) 쿼리 파라미터로 userId 활용부분 삭제했습니다. 
- 리포트 상세조회 /api/v1/report/detail/{intvId}, userId 하드코딩 삭제했습니다. 

현 브랜치에서는 수정이 반영안된 develop 기반이라 테스트가 불가해서,  feat/security 브랜치에서 기존 application-local, docker 띄워서 테스트 확인했습니다.  (패스 완료) 
<img width="415" height="73" alt="image" src="https://github.com/user-attachments/assets/922b3d25-c815-4e5e-aba2-b6696f185710" />

<img width="151" height="176" alt="image" src="https://github.com/user-attachments/assets/e72ff66c-bb6e-44ba-b22f-2ec427662a72" />


앞의 PR 머지되면 develop브랜치 rebase해서 다시 확인하고 슬랙남기겠습니다. 

## 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 체크리스트

- [ ] 빌드 확인 (`./gradlew build`)
- [ ] API 응답 확인
- [ ] 레이어 규칙 준수 (domain / application / infrastructure)
