### PR TITLE
fix: application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,10 +25,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
-
 # ── 서버 설정 (spring.* 네임스페이스 충돌 방지를 위해 분리) ────────────────────
-server:
-  callback-base-url: ${CALLBACK_BASE_URL:http://spring-server:8080}
+  server:
+    callback-base-url: ${SPRING_SERVER_CALLBACK_BASE_URL:http://spring-server:8080}
 
 # ── Report 설정 ────────────────────────────────────────────────────────────
 report:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,8 +26,9 @@ spring:
       hibernate:
         format_sql: true
 # ── 서버 설정 (spring.* 네임스페이스 충돌 방지를 위해 분리) ────────────────────
-  server:
-    callback-base-url: ${SPRING_SERVER_CALLBACK_BASE_URL:http://spring-server:8080}
+server:
+  callback-base-url: ${SPRING_INTERNAL_BASE_URL:http://spring-server:8080}
+
 
 # ── Report 설정 ────────────────────────────────────────────────────────────
 report:


### PR DESCRIPTION
## 관련 이슈
환경변수 대입이 안되는 상황입니다.
spring 서버에서 파이썬 서버에게 요청할 때 callback 주소를 전달하는 과정에서, 
환경변수 대입이 안되는거 같아 환경변수 대입하는 파일을 수정했습니다.  

## 작업 내용
이전에는 CALLBACK_BASE_URL로 작성했습니다. 
aws 환경변수 확인해보니, SPRING_SERVER_CALLBACK_BASE_URL이 있어, 해당 이름으로 수정했습니다. 

관련파일  AiReportRequestor.java
<img width="951" height="319" alt="image" src="https://github.com/user-attachments/assets/322ec947-f7e1-4f2b-85af-e0b4cf2243d7" />


## 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 체크리스트
- [ ] 빌드 확인 (`./gradlew build`)
- [ ] API 응답 확인
- [ ] 레이어 규칙 준수 (domain / application / infrastructure)
