### PR TITLE
fix: url origin에 따른 redirect url 선택 되도록 수정

### DIFF
--- a/src/main/java/com/gamyeon/user/application/port/inbound/OAuthLoginCommand.java
+++ b/src/main/java/com/gamyeon/user/application/port/inbound/OAuthLoginCommand.java
@@ -7,16 +7,18 @@ public class OAuthLoginCommand {
   private final OAuthProvider provider;
   private final String authorizationCode;
   private final String codeVerifier;
+  private final String origin;
 
-  private OAuthLoginCommand(OAuthProvider provider, String authorizationCode, String codeVerifier) {
+  private OAuthLoginCommand(OAuthProvider provider, String authorizationCode, String codeVerifier, String origin) {
     this.provider = provider;
     this.authorizationCode = authorizationCode;
     this.codeVerifier = codeVerifier;
+    this.origin = origin;
   }
 
   public static OAuthLoginCommand of(
-      OAuthProvider provider, String authorizationCode, String codeVerifier) {
-    return new OAuthLoginCommand(provider, authorizationCode, codeVerifier);
+      OAuthProvider provider, String authorizationCode, String codeVerifier, String origin) {
+    return new OAuthLoginCommand(provider, authorizationCode, codeVerifier, origin);
   }
 
   public OAuthProvider getProvider() {
@@ -29,5 +31,9 @@ public class OAuthLoginCommand {
 
   public String getCodeVerifier() {
     return codeVerifier;
+  }
+
+  public String getOrigin() {
+    return origin;
   }
 }

--- a/src/main/java/com/gamyeon/user/application/port/inbound/OAuthLoginCommand.java
+++ b/src/main/java/com/gamyeon/user/application/port/inbound/OAuthLoginCommand.java
@@ -9,7 +9,8 @@ public class OAuthLoginCommand {
   private final String codeVerifier;
   private final String origin;
 
-  private OAuthLoginCommand(OAuthProvider provider, String authorizationCode, String codeVerifier, String origin) {
+  private OAuthLoginCommand(
+      OAuthProvider provider, String authorizationCode, String codeVerifier, String origin) {
     this.provider = provider;
     this.authorizationCode = authorizationCode;
     this.codeVerifier = codeVerifier;

--- a/src/main/java/com/gamyeon/user/application/port/outbound/OAuthPort.java
+++ b/src/main/java/com/gamyeon/user/application/port/outbound/OAuthPort.java
@@ -4,7 +4,7 @@ import com.gamyeon.user.domain.OAuthProvider;
 
 public interface OAuthPort {
 
-  String getAccessToken(OAuthProvider provider, String authorizationCode, String codeVerifier);
+  String getAccessToken(OAuthProvider provider, String authorizationCode, String codeVerifier, String origin);
 
   OAuthUserInfo getUserInfo(OAuthProvider provider, String accessToken);
 

--- a/src/main/java/com/gamyeon/user/application/port/outbound/OAuthPort.java
+++ b/src/main/java/com/gamyeon/user/application/port/outbound/OAuthPort.java
@@ -4,7 +4,8 @@ import com.gamyeon.user.domain.OAuthProvider;
 
 public interface OAuthPort {
 
-  String getAccessToken(OAuthProvider provider, String authorizationCode, String codeVerifier, String origin);
+  String getAccessToken(
+      OAuthProvider provider, String authorizationCode, String codeVerifier, String origin);
 
   OAuthUserInfo getUserInfo(OAuthProvider provider, String accessToken);
 

--- a/src/main/java/com/gamyeon/user/application/service/AuthService.java
+++ b/src/main/java/com/gamyeon/user/application/service/AuthService.java
@@ -42,7 +42,7 @@ public class AuthService implements AuthUseCase {
     String authCode = command.getAuthorizationCode();
 
     String oauthAccessToken =
-        oAuthPort.getAccessToken(provider, authCode, command.getCodeVerifier());
+        oAuthPort.getAccessToken(provider, authCode, command.getCodeVerifier(), command.getOrigin());
     OAuthPort.OAuthUserInfo oAuthUserInfo = oAuthPort.getUserInfo(provider, oauthAccessToken);
 
     String email = resolveEmail(provider, oAuthUserInfo);

--- a/src/main/java/com/gamyeon/user/application/service/AuthService.java
+++ b/src/main/java/com/gamyeon/user/application/service/AuthService.java
@@ -42,7 +42,8 @@ public class AuthService implements AuthUseCase {
     String authCode = command.getAuthorizationCode();
 
     String oauthAccessToken =
-        oAuthPort.getAccessToken(provider, authCode, command.getCodeVerifier(), command.getOrigin());
+        oAuthPort.getAccessToken(
+            provider, authCode, command.getCodeVerifier(), command.getOrigin());
     OAuthPort.OAuthUserInfo oAuthUserInfo = oAuthPort.getUserInfo(provider, oauthAccessToken);
 
     String email = resolveEmail(provider, oAuthUserInfo);

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthAdapter.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthAdapter.java
@@ -33,11 +33,11 @@ public class OAuthAdapter implements OAuthPort {
 
   @Override
   public String getAccessToken(
-      OAuthProvider provider, String authorizationCode, String codeVerifier) {
+      OAuthProvider provider, String authorizationCode, String codeVerifier, String origin) {
     try {
       return switch (provider) {
-        case GOOGLE -> fetchGoogleAccessToken(authorizationCode, codeVerifier);
-        case KAKAO -> fetchKakaoAccessToken(authorizationCode, codeVerifier);
+        case GOOGLE -> fetchGoogleAccessToken(authorizationCode, codeVerifier, origin);
+        case KAKAO -> fetchKakaoAccessToken(authorizationCode, codeVerifier, origin);
       };
     } catch (WebClientResponseException e) {
       log.warn(
@@ -72,13 +72,13 @@ public class OAuthAdapter implements OAuthPort {
     }
   }
 
-  private String fetchGoogleAccessToken(String authorizationCode, String codeVerifier) {
+  private String fetchGoogleAccessToken(String authorizationCode, String codeVerifier, String origin) {
     OAuthProperties.Provider google = oAuthProperties.getGoogle();
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("code", authorizationCode);
     params.add("client_id", google.getClientId());
     params.add("client_secret", google.getClientSecret());
-    params.add("redirect_uri", google.getRedirectUri());
+    params.add("redirect_uri", google.resolveRedirectUri(origin));
     params.add("grant_type", "authorization_code");
     params.add("code_verifier", codeVerifier);
 
@@ -105,13 +105,13 @@ public class OAuthAdapter implements OAuthPort {
         .block();
   }
 
-  private String fetchKakaoAccessToken(String authorizationCode, String codeVerifier) {
+  private String fetchKakaoAccessToken(String authorizationCode, String codeVerifier, String origin) {
     OAuthProperties.Provider kakao = oAuthProperties.getKakao();
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("code", authorizationCode);
     params.add("client_id", kakao.getClientId());
     params.add("client_secret", kakao.getClientSecret());
-    params.add("redirect_uri", kakao.getRedirectUri());
+    params.add("redirect_uri", kakao.resolveRedirectUri(origin));
     params.add("grant_type", "authorization_code");
     params.add("code_verifier", codeVerifier);
 

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthAdapter.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthAdapter.java
@@ -72,7 +72,8 @@ public class OAuthAdapter implements OAuthPort {
     }
   }
 
-  private String fetchGoogleAccessToken(String authorizationCode, String codeVerifier, String origin) {
+  private String fetchGoogleAccessToken(
+      String authorizationCode, String codeVerifier, String origin) {
     OAuthProperties.Provider google = oAuthProperties.getGoogle();
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("code", authorizationCode);
@@ -105,7 +106,8 @@ public class OAuthAdapter implements OAuthPort {
         .block();
   }
 
-  private String fetchKakaoAccessToken(String authorizationCode, String codeVerifier, String origin) {
+  private String fetchKakaoAccessToken(
+      String authorizationCode, String codeVerifier, String origin) {
     OAuthProperties.Provider kakao = oAuthProperties.getKakao();
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("code", authorizationCode);

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
@@ -2,6 +2,9 @@ package com.gamyeon.user.infrastructure.external;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @ConfigurationProperties(prefix = "oauth")
 public class OAuthProperties {
 
@@ -27,7 +30,7 @@ public class OAuthProperties {
   public static class Provider {
     private String clientId;
     private String clientSecret;
-    private String redirectUri;
+    private List<String> redirectUris = new ArrayList<>();
 
     public String getClientId() {
       return clientId;
@@ -45,12 +48,20 @@ public class OAuthProperties {
       this.clientSecret = clientSecret;
     }
 
-    public String getRedirectUri() {
-      return redirectUri;
+    public List<String> getRedirectUris() {
+      return redirectUris;
     }
 
-    public void setRedirectUri(String redirectUri) {
-      this.redirectUri = redirectUri;
+    public void setRedirectUris(List<String> redirectUris) {
+      this.redirectUris = redirectUris;
+    }
+
+    public String resolveRedirectUri(String origin) {
+      if (origin == null) return redirectUris.isEmpty() ? null : redirectUris.get(0);
+      return redirectUris.stream()
+          .filter(uri -> uri.startsWith(origin))
+          .findFirst()
+          .orElse(redirectUris.isEmpty() ? null : redirectUris.get(0));
     }
   }
 }

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
@@ -1,9 +1,8 @@
 package com.gamyeon.user.infrastructure.external;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "oauth")
 public class OAuthProperties {

--- a/src/main/java/com/gamyeon/user/infrastructure/web/AuthController.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/web/AuthController.java
@@ -8,6 +8,7 @@ import com.gamyeon.user.application.port.inbound.LoginResult;
 import com.gamyeon.user.application.port.inbound.OAuthLoginCommand;
 import com.gamyeon.user.domain.OAuthProvider;
 import com.gamyeon.user.domain.UserSuccessCode;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.extern.slf4j.Slf4j;
@@ -32,12 +33,14 @@ public class AuthController {
 
   @PostMapping("/login/{provider}")
   public ResponseEntity<SuccessResponse<LoginResponse>> login(
-      @PathVariable String provider, @Valid @RequestBody LoginRequest request) {
+      @PathVariable String provider, @Valid @RequestBody LoginRequest request,
+      HttpServletRequest httpRequest) {
     log.info("Received login request. provider={}", provider);
 
+    String origin = httpRequest.getHeader("Origin");
     OAuthProvider oAuthProvider = parseProvider(provider);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(oAuthProvider, request.authorizationCode(), request.codeVerifier());
+        OAuthLoginCommand.of(oAuthProvider, request.authorizationCode(), request.codeVerifier(), origin);
     LoginResult result = authUseCase.login(command);
     return ResponseEntity.ok(
         SuccessResponse.of(UserSuccessCode.USER_LOGIN, LoginResponse.from(result)));

--- a/src/main/java/com/gamyeon/user/infrastructure/web/AuthController.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/web/AuthController.java
@@ -33,14 +33,16 @@ public class AuthController {
 
   @PostMapping("/login/{provider}")
   public ResponseEntity<SuccessResponse<LoginResponse>> login(
-      @PathVariable String provider, @Valid @RequestBody LoginRequest request,
+      @PathVariable String provider,
+      @Valid @RequestBody LoginRequest request,
       HttpServletRequest httpRequest) {
     log.info("Received login request. provider={}", provider);
 
     String origin = httpRequest.getHeader("Origin");
     OAuthProvider oAuthProvider = parseProvider(provider);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(oAuthProvider, request.authorizationCode(), request.codeVerifier(), origin);
+        OAuthLoginCommand.of(
+            oAuthProvider, request.authorizationCode(), request.codeVerifier(), origin);
     LoginResult result = authUseCase.login(command);
     return ResponseEntity.ok(
         SuccessResponse.of(UserSuccessCode.USER_LOGIN, LoginResponse.from(result)));

--- a/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
+++ b/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
@@ -54,9 +54,9 @@ class AuthServiceTest {
   @DisplayName("TAS-001 - 신규 유저 로그인 시 유저를 저장하고 JWT를 발급해야 한다")
   void shouldSaveUserAndIssueJwtWhenNewUserLogsIn() {
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier");
+        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier"))
+    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -80,9 +80,9 @@ class AuthServiceTest {
   void shouldNotSaveUserWhenExistingUserLogsIn() {
     User existingUser = existingUser(1L, OAuthProvider.GOOGLE, "google-123");
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier");
+        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier"))
+    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -102,9 +102,9 @@ class AuthServiceTest {
   void shouldThrowExceptionWhenBannedUserLogsIn() {
     User bannedUser = userWithStatus(1L, OAuthProvider.GOOGLE, "google-123", UserStatus.BANNED);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier");
+        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier"))
+    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -120,9 +120,9 @@ class AuthServiceTest {
   void shouldThrowExceptionWhenWithdrewUserLogsIn() {
     User withdrewUser = userWithStatus(1L, OAuthProvider.GOOGLE, "google-123", UserStatus.WITHDREW);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier");
+        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier"))
+    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));

--- a/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
+++ b/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
@@ -54,9 +54,12 @@ class AuthServiceTest {
   @DisplayName("TAS-001 - 신규 유저 로그인 시 유저를 저장하고 JWT를 발급해야 한다")
   void shouldSaveUserAndIssueJwtWhenNewUserLogsIn() {
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
+        OAuthLoginCommand.of(
+            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
+    given(
+            oAuthPort.getAccessToken(
+                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -80,9 +83,12 @@ class AuthServiceTest {
   void shouldNotSaveUserWhenExistingUserLogsIn() {
     User existingUser = existingUser(1L, OAuthProvider.GOOGLE, "google-123");
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
+        OAuthLoginCommand.of(
+            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
+    given(
+            oAuthPort.getAccessToken(
+                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -102,9 +108,12 @@ class AuthServiceTest {
   void shouldThrowExceptionWhenBannedUserLogsIn() {
     User bannedUser = userWithStatus(1L, OAuthProvider.GOOGLE, "google-123", UserStatus.BANNED);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
+        OAuthLoginCommand.of(
+            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
+    given(
+            oAuthPort.getAccessToken(
+                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -120,9 +129,12 @@ class AuthServiceTest {
   void shouldThrowExceptionWhenWithdrewUserLogsIn() {
     User withdrewUser = userWithStatus(1L, OAuthProvider.GOOGLE, "google-123", UserStatus.WITHDREW);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
+        OAuthLoginCommand.of(
+            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
+    given(
+            oAuthPort.getAccessToken(
+                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
로컬, dev, prod 설정이 필요함에 따라 redirect url을 상황에 맞게 설정되도록 바꿀 필요가 있음

[AS IS]
기존 redirect url 하나만 설정이 가능

[TO BE]
여러 redirect url에 대해 설정이 가능 

## 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타

## 체크리스트
- [ ] 빌드 확인 (`./gradlew build`)
- [ ] API 응답 확인
- [ ] 레이어 규칙 준수 (domain / application / infrastructure)
