### PR TITLE
hotfix: 구조 변경: Origin 헤더 → 요청 Body의 redirectUri

### DIFF
--- a/src/main/java/com/gamyeon/user/application/port/inbound/OAuthLoginCommand.java
+++ b/src/main/java/com/gamyeon/user/application/port/inbound/OAuthLoginCommand.java
@@ -7,19 +7,19 @@ public class OAuthLoginCommand {
   private final OAuthProvider provider;
   private final String authorizationCode;
   private final String codeVerifier;
-  private final String origin;
+  private final String redirectUri;
 
   private OAuthLoginCommand(
-      OAuthProvider provider, String authorizationCode, String codeVerifier, String origin) {
+      OAuthProvider provider, String authorizationCode, String codeVerifier, String redirectUri) {
     this.provider = provider;
     this.authorizationCode = authorizationCode;
     this.codeVerifier = codeVerifier;
-    this.origin = origin;
+    this.redirectUri = redirectUri;
   }
 
   public static OAuthLoginCommand of(
-      OAuthProvider provider, String authorizationCode, String codeVerifier, String origin) {
-    return new OAuthLoginCommand(provider, authorizationCode, codeVerifier, origin);
+      OAuthProvider provider, String authorizationCode, String codeVerifier, String redirectUri) {
+    return new OAuthLoginCommand(provider, authorizationCode, codeVerifier, redirectUri);
   }
 
   public OAuthProvider getProvider() {
@@ -34,7 +34,7 @@ public class OAuthLoginCommand {
     return codeVerifier;
   }
 
-  public String getOrigin() {
-    return origin;
+  public String getRedirectUri() {
+    return redirectUri;
   }
 }

--- a/src/main/java/com/gamyeon/user/application/port/inbound/OAuthLoginCommand.java
+++ b/src/main/java/com/gamyeon/user/application/port/inbound/OAuthLoginCommand.java
@@ -7,16 +7,18 @@ public class OAuthLoginCommand {
   private final OAuthProvider provider;
   private final String authorizationCode;
   private final String codeVerifier;
+  private final String origin;
 
-  private OAuthLoginCommand(OAuthProvider provider, String authorizationCode, String codeVerifier) {
+  private OAuthLoginCommand(OAuthProvider provider, String authorizationCode, String codeVerifier, String origin) {
     this.provider = provider;
     this.authorizationCode = authorizationCode;
     this.codeVerifier = codeVerifier;
+    this.origin = origin;
   }
 
   public static OAuthLoginCommand of(
-      OAuthProvider provider, String authorizationCode, String codeVerifier) {
-    return new OAuthLoginCommand(provider, authorizationCode, codeVerifier);
+      OAuthProvider provider, String authorizationCode, String codeVerifier, String origin) {
+    return new OAuthLoginCommand(provider, authorizationCode, codeVerifier, origin);
   }
 
   public OAuthProvider getProvider() {
@@ -29,5 +31,9 @@ public class OAuthLoginCommand {
 
   public String getCodeVerifier() {
     return codeVerifier;
+  }
+
+  public String getOrigin() {
+    return origin;
   }
 }

--- a/src/main/java/com/gamyeon/user/application/port/inbound/OAuthLoginCommand.java
+++ b/src/main/java/com/gamyeon/user/application/port/inbound/OAuthLoginCommand.java
@@ -9,7 +9,8 @@ public class OAuthLoginCommand {
   private final String codeVerifier;
   private final String origin;
 
-  private OAuthLoginCommand(OAuthProvider provider, String authorizationCode, String codeVerifier, String origin) {
+  private OAuthLoginCommand(
+      OAuthProvider provider, String authorizationCode, String codeVerifier, String origin) {
     this.provider = provider;
     this.authorizationCode = authorizationCode;
     this.codeVerifier = codeVerifier;

--- a/src/main/java/com/gamyeon/user/application/port/outbound/OAuthPort.java
+++ b/src/main/java/com/gamyeon/user/application/port/outbound/OAuthPort.java
@@ -4,7 +4,7 @@ import com.gamyeon.user.domain.OAuthProvider;
 
 public interface OAuthPort {
 
-  String getAccessToken(OAuthProvider provider, String authorizationCode, String codeVerifier);
+  String getAccessToken(OAuthProvider provider, String authorizationCode, String codeVerifier, String origin);
 
   OAuthUserInfo getUserInfo(OAuthProvider provider, String accessToken);
 

--- a/src/main/java/com/gamyeon/user/application/port/outbound/OAuthPort.java
+++ b/src/main/java/com/gamyeon/user/application/port/outbound/OAuthPort.java
@@ -4,7 +4,8 @@ import com.gamyeon.user.domain.OAuthProvider;
 
 public interface OAuthPort {
 
-  String getAccessToken(OAuthProvider provider, String authorizationCode, String codeVerifier, String origin);
+  String getAccessToken(
+      OAuthProvider provider, String authorizationCode, String codeVerifier, String origin);
 
   OAuthUserInfo getUserInfo(OAuthProvider provider, String accessToken);
 

--- a/src/main/java/com/gamyeon/user/application/port/outbound/OAuthPort.java
+++ b/src/main/java/com/gamyeon/user/application/port/outbound/OAuthPort.java
@@ -5,7 +5,7 @@ import com.gamyeon.user.domain.OAuthProvider;
 public interface OAuthPort {
 
   String getAccessToken(
-      OAuthProvider provider, String authorizationCode, String codeVerifier, String origin);
+      OAuthProvider provider, String authorizationCode, String codeVerifier, String redirectUri);
 
   OAuthUserInfo getUserInfo(OAuthProvider provider, String accessToken);
 

--- a/src/main/java/com/gamyeon/user/application/service/AuthService.java
+++ b/src/main/java/com/gamyeon/user/application/service/AuthService.java
@@ -42,7 +42,7 @@ public class AuthService implements AuthUseCase {
     String authCode = command.getAuthorizationCode();
 
     String oauthAccessToken =
-        oAuthPort.getAccessToken(provider, authCode, command.getCodeVerifier());
+        oAuthPort.getAccessToken(provider, authCode, command.getCodeVerifier(), command.getOrigin());
     OAuthPort.OAuthUserInfo oAuthUserInfo = oAuthPort.getUserInfo(provider, oauthAccessToken);
 
     String email = resolveEmail(provider, oAuthUserInfo);

--- a/src/main/java/com/gamyeon/user/application/service/AuthService.java
+++ b/src/main/java/com/gamyeon/user/application/service/AuthService.java
@@ -43,7 +43,7 @@ public class AuthService implements AuthUseCase {
 
     String oauthAccessToken =
         oAuthPort.getAccessToken(
-            provider, authCode, command.getCodeVerifier(), command.getOrigin());
+            provider, authCode, command.getCodeVerifier(), command.getRedirectUri());
     OAuthPort.OAuthUserInfo oAuthUserInfo = oAuthPort.getUserInfo(provider, oauthAccessToken);
 
     String email = resolveEmail(provider, oAuthUserInfo);

--- a/src/main/java/com/gamyeon/user/application/service/AuthService.java
+++ b/src/main/java/com/gamyeon/user/application/service/AuthService.java
@@ -42,7 +42,8 @@ public class AuthService implements AuthUseCase {
     String authCode = command.getAuthorizationCode();
 
     String oauthAccessToken =
-        oAuthPort.getAccessToken(provider, authCode, command.getCodeVerifier(), command.getOrigin());
+        oAuthPort.getAccessToken(
+            provider, authCode, command.getCodeVerifier(), command.getOrigin());
     OAuthPort.OAuthUserInfo oAuthUserInfo = oAuthPort.getUserInfo(provider, oauthAccessToken);
 
     String email = resolveEmail(provider, oAuthUserInfo);

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthAdapter.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthAdapter.java
@@ -33,11 +33,11 @@ public class OAuthAdapter implements OAuthPort {
 
   @Override
   public String getAccessToken(
-      OAuthProvider provider, String authorizationCode, String codeVerifier) {
+      OAuthProvider provider, String authorizationCode, String codeVerifier, String origin) {
     try {
       return switch (provider) {
-        case GOOGLE -> fetchGoogleAccessToken(authorizationCode, codeVerifier);
-        case KAKAO -> fetchKakaoAccessToken(authorizationCode, codeVerifier);
+        case GOOGLE -> fetchGoogleAccessToken(authorizationCode, codeVerifier, origin);
+        case KAKAO -> fetchKakaoAccessToken(authorizationCode, codeVerifier, origin);
       };
     } catch (WebClientResponseException e) {
       log.warn(
@@ -72,13 +72,13 @@ public class OAuthAdapter implements OAuthPort {
     }
   }
 
-  private String fetchGoogleAccessToken(String authorizationCode, String codeVerifier) {
+  private String fetchGoogleAccessToken(String authorizationCode, String codeVerifier, String origin) {
     OAuthProperties.Provider google = oAuthProperties.getGoogle();
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("code", authorizationCode);
     params.add("client_id", google.getClientId());
     params.add("client_secret", google.getClientSecret());
-    params.add("redirect_uri", google.getRedirectUri());
+    params.add("redirect_uri", google.resolveRedirectUri(origin));
     params.add("grant_type", "authorization_code");
     params.add("code_verifier", codeVerifier);
 
@@ -105,13 +105,13 @@ public class OAuthAdapter implements OAuthPort {
         .block();
   }
 
-  private String fetchKakaoAccessToken(String authorizationCode, String codeVerifier) {
+  private String fetchKakaoAccessToken(String authorizationCode, String codeVerifier, String origin) {
     OAuthProperties.Provider kakao = oAuthProperties.getKakao();
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("code", authorizationCode);
     params.add("client_id", kakao.getClientId());
     params.add("client_secret", kakao.getClientSecret());
-    params.add("redirect_uri", kakao.getRedirectUri());
+    params.add("redirect_uri", kakao.resolveRedirectUri(origin));
     params.add("grant_type", "authorization_code");
     params.add("code_verifier", codeVerifier);
 

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthAdapter.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthAdapter.java
@@ -75,11 +75,14 @@ public class OAuthAdapter implements OAuthPort {
   private String fetchGoogleAccessToken(
       String authorizationCode, String codeVerifier, String origin) {
     OAuthProperties.Provider google = oAuthProperties.getGoogle();
+    String resolvedRedirectUri = google.resolveRedirectUri(origin);
+    // INFO: Google에 실제로 전송하는 redirect_uri 확인
+    log.info("[OAuth] GOOGLE 토큰 요청 — origin='{}', redirect_uri='{}'", origin, resolvedRedirectUri);
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("code", authorizationCode);
     params.add("client_id", google.getClientId());
     params.add("client_secret", google.getClientSecret());
-    params.add("redirect_uri", google.resolveRedirectUri(origin));
+    params.add("redirect_uri", resolvedRedirectUri);
     params.add("grant_type", "authorization_code");
     params.add("code_verifier", codeVerifier);
 
@@ -109,11 +112,14 @@ public class OAuthAdapter implements OAuthPort {
   private String fetchKakaoAccessToken(
       String authorizationCode, String codeVerifier, String origin) {
     OAuthProperties.Provider kakao = oAuthProperties.getKakao();
+    String resolvedRedirectUri = kakao.resolveRedirectUri(origin);
+    // INFO: Kakao에 실제로 전송하는 redirect_uri 확인
+    log.info("[OAuth] KAKAO 토큰 요청 — origin='{}', redirect_uri='{}'", origin, resolvedRedirectUri);
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("code", authorizationCode);
     params.add("client_id", kakao.getClientId());
     params.add("client_secret", kakao.getClientSecret());
-    params.add("redirect_uri", kakao.resolveRedirectUri(origin));
+    params.add("redirect_uri", resolvedRedirectUri);
     params.add("grant_type", "authorization_code");
     params.add("code_verifier", codeVerifier);
 

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthAdapter.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthAdapter.java
@@ -72,7 +72,8 @@ public class OAuthAdapter implements OAuthPort {
     }
   }
 
-  private String fetchGoogleAccessToken(String authorizationCode, String codeVerifier, String origin) {
+  private String fetchGoogleAccessToken(
+      String authorizationCode, String codeVerifier, String origin) {
     OAuthProperties.Provider google = oAuthProperties.getGoogle();
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("code", authorizationCode);
@@ -105,7 +106,8 @@ public class OAuthAdapter implements OAuthPort {
         .block();
   }
 
-  private String fetchKakaoAccessToken(String authorizationCode, String codeVerifier, String origin) {
+  private String fetchKakaoAccessToken(
+      String authorizationCode, String codeVerifier, String origin) {
     OAuthProperties.Provider kakao = oAuthProperties.getKakao();
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("code", authorizationCode);

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthAdapter.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthAdapter.java
@@ -33,11 +33,11 @@ public class OAuthAdapter implements OAuthPort {
 
   @Override
   public String getAccessToken(
-      OAuthProvider provider, String authorizationCode, String codeVerifier, String origin) {
+      OAuthProvider provider, String authorizationCode, String codeVerifier, String redirectUri) {
     try {
       return switch (provider) {
-        case GOOGLE -> fetchGoogleAccessToken(authorizationCode, codeVerifier, origin);
-        case KAKAO -> fetchKakaoAccessToken(authorizationCode, codeVerifier, origin);
+        case GOOGLE -> fetchGoogleAccessToken(authorizationCode, codeVerifier, redirectUri);
+        case KAKAO -> fetchKakaoAccessToken(authorizationCode, codeVerifier, redirectUri);
       };
     } catch (WebClientResponseException e) {
       log.warn(
@@ -73,16 +73,20 @@ public class OAuthAdapter implements OAuthPort {
   }
 
   private String fetchGoogleAccessToken(
-      String authorizationCode, String codeVerifier, String origin) {
+      String authorizationCode, String codeVerifier, String redirectUri) {
     OAuthProperties.Provider google = oAuthProperties.getGoogle();
-    String resolvedRedirectUri = google.resolveRedirectUri(origin);
-    // INFO: Google에 실제로 전송하는 redirect_uri 확인
-    log.info("[OAuth] GOOGLE 토큰 요청 — origin='{}', redirect_uri='{}'", origin, resolvedRedirectUri);
+
+    // INFO: Google에 실제로 전송할 redirect_uri 확인 (허용 목록 검증 포함)
+    log.info("[OAuth] GOOGLE 토큰 요청 — redirect_uri='{}'", redirectUri);
+    if (!google.isAllowedRedirectUri(redirectUri)) {
+      throw new CommonException(CommonErrorCode.INVALID_INPUT);
+    }
+
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("code", authorizationCode);
     params.add("client_id", google.getClientId());
     params.add("client_secret", google.getClientSecret());
-    params.add("redirect_uri", resolvedRedirectUri);
+    params.add("redirect_uri", redirectUri);
     params.add("grant_type", "authorization_code");
     params.add("code_verifier", codeVerifier);
 
@@ -110,16 +114,20 @@ public class OAuthAdapter implements OAuthPort {
   }
 
   private String fetchKakaoAccessToken(
-      String authorizationCode, String codeVerifier, String origin) {
+      String authorizationCode, String codeVerifier, String redirectUri) {
     OAuthProperties.Provider kakao = oAuthProperties.getKakao();
-    String resolvedRedirectUri = kakao.resolveRedirectUri(origin);
-    // INFO: Kakao에 실제로 전송하는 redirect_uri 확인
-    log.info("[OAuth] KAKAO 토큰 요청 — origin='{}', redirect_uri='{}'", origin, resolvedRedirectUri);
+
+    // INFO: Kakao에 실제로 전송할 redirect_uri 확인 (허용 목록 검증 포함)
+    log.info("[OAuth] KAKAO 토큰 요청 — redirect_uri='{}'", redirectUri);
+    if (!kakao.isAllowedRedirectUri(redirectUri)) {
+      throw new CommonException(CommonErrorCode.INVALID_INPUT);
+    }
+
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("code", authorizationCode);
     params.add("client_id", kakao.getClientId());
     params.add("client_secret", kakao.getClientSecret());
-    params.add("redirect_uri", resolvedRedirectUri);
+    params.add("redirect_uri", redirectUri);
     params.add("grant_type", "authorization_code");
     params.add("code_verifier", codeVerifier);
 

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
@@ -64,7 +64,9 @@ public class OAuthProperties {
      * 프론트엔드가 전달한 redirectUri가 허용 목록에 있는지 검증합니다.
      *
      * <p>ERROR: 환경변수 바인딩 실패로 목록이 비어 있는 경우
+     *
      * <p>ERROR: 허용 목록에 없는 URI가 요청된 경우 (잘못된 클라이언트 설정 또는 비정상 요청)
+     *
      * <p>DEBUG: 검증 성공 시 URI 출력
      */
     public boolean isAllowedRedirectUri(String redirectUri) {
@@ -85,8 +87,7 @@ public class OAuthProperties {
         log.debug("[OAuth] redirectUri 검증 성공: '{}'", redirectUri);
       } else {
         // ERROR: 허용되지 않은 URI — 잘못된 클라이언트 설정이거나 비정상 요청
-        log.error(
-            "[OAuth] 허용되지 않은 redirectUri 요청: '{}'. 허용 목록: {}", redirectUri, redirectUris);
+        log.error("[OAuth] 허용되지 않은 redirectUri 요청: '{}'. 허용 목록: {}", redirectUri, redirectUris);
       }
 
       return allowed;

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
@@ -2,6 +2,9 @@ package com.gamyeon.user.infrastructure.external;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @ConfigurationProperties(prefix = "oauth")
 public class OAuthProperties {
 
@@ -27,7 +30,7 @@ public class OAuthProperties {
   public static class Provider {
     private String clientId;
     private String clientSecret;
-    private String redirectUri;
+    private List<String> redirectUris = new ArrayList<>();
 
     public String getClientId() {
       return clientId;
@@ -45,12 +48,20 @@ public class OAuthProperties {
       this.clientSecret = clientSecret;
     }
 
-    public String getRedirectUri() {
-      return redirectUri;
+    public List<String> getRedirectUris() {
+      return redirectUris;
     }
 
-    public void setRedirectUri(String redirectUri) {
-      this.redirectUri = redirectUri;
+    public void setRedirectUris(List<String> redirectUris) {
+      this.redirectUris = redirectUris;
+    }
+
+    public String resolveRedirectUri(String origin) {
+      if (origin == null) return redirectUris.isEmpty() ? null : redirectUris.get(0);
+      return redirectUris.stream()
+          .filter(uri -> uri.startsWith(origin))
+          .findFirst()
+          .orElse(redirectUris.isEmpty() ? null : redirectUris.get(0));
     }
   }
 }

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
@@ -75,9 +75,7 @@ public class OAuthProperties {
       // WARN: Origin 헤더가 없는 경우 (nginx가 헤더를 제거했거나, 비브라우저 클라이언트)
       if (origin == null || origin.isBlank()) {
         String fallback = redirectUris.get(0);
-        log.warn(
-            "[OAuth] Origin 헤더가 없습니다. 첫 번째 URI로 폴백합니다. fallback={}",
-            fallback);
+        log.warn("[OAuth] Origin 헤더가 없습니다. 첫 번째 URI로 폴백합니다. fallback={}", fallback);
         return fallback;
       }
 
@@ -86,7 +84,9 @@ public class OAuthProperties {
 
       return redirectUris.stream()
           .filter(uri -> uri.startsWith(origin))
-          .peek(matched -> log.debug("[OAuth] 매칭 성공: origin='{}' → redirectUri='{}'", origin, matched))
+          .peek(
+              matched ->
+                  log.debug("[OAuth] 매칭 성공: origin='{}' → redirectUri='{}'", origin, matched))
           .findFirst()
           .orElseGet(
               () -> {

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
@@ -2,6 +2,8 @@ package com.gamyeon.user.infrastructure.external;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "oauth")
@@ -27,6 +29,9 @@ public class OAuthProperties {
   }
 
   public static class Provider {
+
+    private static final Logger log = LoggerFactory.getLogger(Provider.class);
+
     private String clientId;
     private String clientSecret;
     private List<String> redirectUris = new ArrayList<>();
@@ -56,11 +61,45 @@ public class OAuthProperties {
     }
 
     public String resolveRedirectUri(String origin) {
-      if (origin == null) return redirectUris.isEmpty() ? null : redirectUris.get(0);
+      // ERROR: 설정 자체가 잘못된 경우 (env URIS가 비어 있거나 바인딩 실패)
+      if (redirectUris.isEmpty()) {
+        log.error(
+            "[OAuth] redirectUris 목록이 비어 있습니다. "
+                + "환경변수 OAUTH_*_REDIRECT_URIS가 올바르게 설정되었는지 확인하세요.");
+        return null;
+      }
+
+      // DEBUG: 현재 로드된 redirect URI 목록 전체 출력
+      log.debug("[OAuth] 등록된 redirectUris 목록 (총 {}개): {}", redirectUris.size(), redirectUris);
+
+      // WARN: Origin 헤더가 없는 경우 (nginx가 헤더를 제거했거나, 비브라우저 클라이언트)
+      if (origin == null || origin.isBlank()) {
+        String fallback = redirectUris.get(0);
+        log.warn(
+            "[OAuth] Origin 헤더가 없습니다. 첫 번째 URI로 폴백합니다. fallback={}",
+            fallback);
+        return fallback;
+      }
+
+      // DEBUG: 수신된 Origin 값과 매칭 시도 과정 출력
+      log.debug("[OAuth] Origin 헤더 수신: '{}' — redirectUris에서 매칭 시도", origin);
+
       return redirectUris.stream()
           .filter(uri -> uri.startsWith(origin))
+          .peek(matched -> log.debug("[OAuth] 매칭 성공: origin='{}' → redirectUri='{}'", origin, matched))
           .findFirst()
-          .orElse(redirectUris.isEmpty() ? null : redirectUris.get(0));
+          .orElseGet(
+              () -> {
+                String fallback = redirectUris.get(0);
+                // WARN: origin이 있지만 매칭되는 URI가 없는 경우
+                log.warn(
+                    "[OAuth] origin='{}' 에 매칭되는 redirectUri가 없습니다. "
+                        + "등록된 목록={}, 첫 번째 URI로 폴백합니다. fallback='{}'",
+                    origin,
+                    redirectUris,
+                    fallback);
+                return fallback;
+              });
     }
   }
 }

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
@@ -1,9 +1,8 @@
 package com.gamyeon.user.infrastructure.external;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "oauth")
 public class OAuthProperties {

--- a/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/external/OAuthProperties.java
@@ -60,46 +60,36 @@ public class OAuthProperties {
       this.redirectUris = redirectUris;
     }
 
-    public String resolveRedirectUri(String origin) {
-      // ERROR: 설정 자체가 잘못된 경우 (env URIS가 비어 있거나 바인딩 실패)
+    /**
+     * 프론트엔드가 전달한 redirectUri가 허용 목록에 있는지 검증합니다.
+     *
+     * <p>ERROR: 환경변수 바인딩 실패로 목록이 비어 있는 경우
+     * <p>ERROR: 허용 목록에 없는 URI가 요청된 경우 (잘못된 클라이언트 설정 또는 비정상 요청)
+     * <p>DEBUG: 검증 성공 시 URI 출력
+     */
+    public boolean isAllowedRedirectUri(String redirectUri) {
+      // ERROR: 환경변수 OAUTH_*_REDIRECT_URIS 바인딩 자체가 실패한 경우
       if (redirectUris.isEmpty()) {
         log.error(
             "[OAuth] redirectUris 목록이 비어 있습니다. "
                 + "환경변수 OAUTH_*_REDIRECT_URIS가 올바르게 설정되었는지 확인하세요.");
-        return null;
+        return false;
       }
 
-      // DEBUG: 현재 로드된 redirect URI 목록 전체 출력
-      log.debug("[OAuth] 등록된 redirectUris 목록 (총 {}개): {}", redirectUris.size(), redirectUris);
+      // DEBUG: 허용 목록 전체 출력
+      log.debug("[OAuth] 등록된 redirectUris 허용 목록 (총 {}개): {}", redirectUris.size(), redirectUris);
 
-      // WARN: Origin 헤더가 없는 경우 (nginx가 헤더를 제거했거나, 비브라우저 클라이언트)
-      if (origin == null || origin.isBlank()) {
-        String fallback = redirectUris.get(0);
-        log.warn("[OAuth] Origin 헤더가 없습니다. 첫 번째 URI로 폴백합니다. fallback={}", fallback);
-        return fallback;
+      boolean allowed = redirectUri != null && redirectUris.contains(redirectUri);
+
+      if (allowed) {
+        log.debug("[OAuth] redirectUri 검증 성공: '{}'", redirectUri);
+      } else {
+        // ERROR: 허용되지 않은 URI — 잘못된 클라이언트 설정이거나 비정상 요청
+        log.error(
+            "[OAuth] 허용되지 않은 redirectUri 요청: '{}'. 허용 목록: {}", redirectUri, redirectUris);
       }
 
-      // DEBUG: 수신된 Origin 값과 매칭 시도 과정 출력
-      log.debug("[OAuth] Origin 헤더 수신: '{}' — redirectUris에서 매칭 시도", origin);
-
-      return redirectUris.stream()
-          .filter(uri -> uri.startsWith(origin))
-          .peek(
-              matched ->
-                  log.debug("[OAuth] 매칭 성공: origin='{}' → redirectUri='{}'", origin, matched))
-          .findFirst()
-          .orElseGet(
-              () -> {
-                String fallback = redirectUris.get(0);
-                // WARN: origin이 있지만 매칭되는 URI가 없는 경우
-                log.warn(
-                    "[OAuth] origin='{}' 에 매칭되는 redirectUri가 없습니다. "
-                        + "등록된 목록={}, 첫 번째 URI로 폴백합니다. fallback='{}'",
-                    origin,
-                    redirectUris,
-                    fallback);
-                return fallback;
-              });
+      return allowed;
     }
   }
 }

--- a/src/main/java/com/gamyeon/user/infrastructure/web/AuthController.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/web/AuthController.java
@@ -33,12 +33,16 @@ public class AuthController {
   @PostMapping("/login/{provider}")
   public ResponseEntity<SuccessResponse<LoginResponse>> login(
       @PathVariable String provider, @Valid @RequestBody LoginRequest request) {
-    log.info("Received login request. provider={}, redirectUri={}", provider, request.redirectUri());
+    log.info(
+        "Received login request. provider={}, redirectUri={}", provider, request.redirectUri());
 
     OAuthProvider oAuthProvider = parseProvider(provider);
     OAuthLoginCommand command =
         OAuthLoginCommand.of(
-            oAuthProvider, request.authorizationCode(), request.codeVerifier(), request.redirectUri());
+            oAuthProvider,
+            request.authorizationCode(),
+            request.codeVerifier(),
+            request.redirectUri());
     LoginResult result = authUseCase.login(command);
     return ResponseEntity.ok(
         SuccessResponse.of(UserSuccessCode.USER_LOGIN, LoginResponse.from(result)));

--- a/src/main/java/com/gamyeon/user/infrastructure/web/AuthController.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/web/AuthController.java
@@ -8,7 +8,6 @@ import com.gamyeon.user.application.port.inbound.LoginResult;
 import com.gamyeon.user.application.port.inbound.OAuthLoginCommand;
 import com.gamyeon.user.domain.OAuthProvider;
 import com.gamyeon.user.domain.UserSuccessCode;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.extern.slf4j.Slf4j;
@@ -33,16 +32,13 @@ public class AuthController {
 
   @PostMapping("/login/{provider}")
   public ResponseEntity<SuccessResponse<LoginResponse>> login(
-      @PathVariable String provider,
-      @Valid @RequestBody LoginRequest request,
-      HttpServletRequest httpRequest) {
-    log.info("Received login request. provider={}", provider);
+      @PathVariable String provider, @Valid @RequestBody LoginRequest request) {
+    log.info("Received login request. provider={}, redirectUri={}", provider, request.redirectUri());
 
-    String origin = httpRequest.getHeader("Origin");
     OAuthProvider oAuthProvider = parseProvider(provider);
     OAuthLoginCommand command =
         OAuthLoginCommand.of(
-            oAuthProvider, request.authorizationCode(), request.codeVerifier(), origin);
+            oAuthProvider, request.authorizationCode(), request.codeVerifier(), request.redirectUri());
     LoginResult result = authUseCase.login(command);
     return ResponseEntity.ok(
         SuccessResponse.of(UserSuccessCode.USER_LOGIN, LoginResponse.from(result)));
@@ -74,7 +70,10 @@ public class AuthController {
     };
   }
 
-  public record LoginRequest(@NotBlank String authorizationCode, @NotBlank String codeVerifier) {}
+  public record LoginRequest(
+      @NotBlank String authorizationCode,
+      @NotBlank String codeVerifier,
+      @NotBlank String redirectUri) {}
 
   public record ReissueRequest(@NotBlank String refreshToken) {}
 

--- a/src/main/java/com/gamyeon/user/infrastructure/web/AuthController.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/web/AuthController.java
@@ -8,6 +8,7 @@ import com.gamyeon.user.application.port.inbound.LoginResult;
 import com.gamyeon.user.application.port.inbound.OAuthLoginCommand;
 import com.gamyeon.user.domain.OAuthProvider;
 import com.gamyeon.user.domain.UserSuccessCode;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.extern.slf4j.Slf4j;
@@ -32,12 +33,14 @@ public class AuthController {
 
   @PostMapping("/login/{provider}")
   public ResponseEntity<SuccessResponse<LoginResponse>> login(
-      @PathVariable String provider, @Valid @RequestBody LoginRequest request) {
+      @PathVariable String provider, @Valid @RequestBody LoginRequest request,
+      HttpServletRequest httpRequest) {
     log.info("Received login request. provider={}", provider);
 
+    String origin = httpRequest.getHeader("Origin");
     OAuthProvider oAuthProvider = parseProvider(provider);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(oAuthProvider, request.authorizationCode(), request.codeVerifier());
+        OAuthLoginCommand.of(oAuthProvider, request.authorizationCode(), request.codeVerifier(), origin);
     LoginResult result = authUseCase.login(command);
     return ResponseEntity.ok(
         SuccessResponse.of(UserSuccessCode.USER_LOGIN, LoginResponse.from(result)));

--- a/src/main/java/com/gamyeon/user/infrastructure/web/AuthController.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/web/AuthController.java
@@ -33,14 +33,16 @@ public class AuthController {
 
   @PostMapping("/login/{provider}")
   public ResponseEntity<SuccessResponse<LoginResponse>> login(
-      @PathVariable String provider, @Valid @RequestBody LoginRequest request,
+      @PathVariable String provider,
+      @Valid @RequestBody LoginRequest request,
       HttpServletRequest httpRequest) {
     log.info("Received login request. provider={}", provider);
 
     String origin = httpRequest.getHeader("Origin");
     OAuthProvider oAuthProvider = parseProvider(provider);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(oAuthProvider, request.authorizationCode(), request.codeVerifier(), origin);
+        OAuthLoginCommand.of(
+            oAuthProvider, request.authorizationCode(), request.codeVerifier(), origin);
     LoginResult result = authUseCase.login(command);
     return ResponseEntity.ok(
         SuccessResponse.of(UserSuccessCode.USER_LOGIN, LoginResponse.from(result)));

--- a/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
+++ b/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
@@ -54,9 +54,9 @@ class AuthServiceTest {
   @DisplayName("TAS-001 - 신규 유저 로그인 시 유저를 저장하고 JWT를 발급해야 한다")
   void shouldSaveUserAndIssueJwtWhenNewUserLogsIn() {
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier");
+        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier"))
+    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -80,9 +80,9 @@ class AuthServiceTest {
   void shouldNotSaveUserWhenExistingUserLogsIn() {
     User existingUser = existingUser(1L, OAuthProvider.GOOGLE, "google-123");
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier");
+        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier"))
+    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -102,9 +102,9 @@ class AuthServiceTest {
   void shouldThrowExceptionWhenBannedUserLogsIn() {
     User bannedUser = userWithStatus(1L, OAuthProvider.GOOGLE, "google-123", UserStatus.BANNED);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier");
+        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier"))
+    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -120,9 +120,9 @@ class AuthServiceTest {
   void shouldThrowExceptionWhenWithdrewUserLogsIn() {
     User withdrewUser = userWithStatus(1L, OAuthProvider.GOOGLE, "google-123", UserStatus.WITHDREW);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier");
+        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier"))
+    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));

--- a/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
+++ b/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
@@ -54,9 +54,12 @@ class AuthServiceTest {
   @DisplayName("TAS-001 - 신규 유저 로그인 시 유저를 저장하고 JWT를 발급해야 한다")
   void shouldSaveUserAndIssueJwtWhenNewUserLogsIn() {
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
+        OAuthLoginCommand.of(
+            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
+    given(
+            oAuthPort.getAccessToken(
+                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -80,9 +83,12 @@ class AuthServiceTest {
   void shouldNotSaveUserWhenExistingUserLogsIn() {
     User existingUser = existingUser(1L, OAuthProvider.GOOGLE, "google-123");
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
+        OAuthLoginCommand.of(
+            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
+    given(
+            oAuthPort.getAccessToken(
+                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -102,9 +108,12 @@ class AuthServiceTest {
   void shouldThrowExceptionWhenBannedUserLogsIn() {
     User bannedUser = userWithStatus(1L, OAuthProvider.GOOGLE, "google-123", UserStatus.BANNED);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
+        OAuthLoginCommand.of(
+            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
+    given(
+            oAuthPort.getAccessToken(
+                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -120,9 +129,12 @@ class AuthServiceTest {
   void shouldThrowExceptionWhenWithdrewUserLogsIn() {
     User withdrewUser = userWithStatus(1L, OAuthProvider.GOOGLE, "google-123", UserStatus.WITHDREW);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
+        OAuthLoginCommand.of(
+            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
+    given(
+            oAuthPort.getAccessToken(
+                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));

--- a/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
+++ b/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
@@ -55,11 +55,11 @@ class AuthServiceTest {
   void shouldSaveUserAndIssueJwtWhenNewUserLogsIn() {
     OAuthLoginCommand command =
         OAuthLoginCommand.of(
-            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
+            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin");
 
     given(
             oAuthPort.getAccessToken(
-                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
+                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -84,11 +84,11 @@ class AuthServiceTest {
     User existingUser = existingUser(1L, OAuthProvider.GOOGLE, "google-123");
     OAuthLoginCommand command =
         OAuthLoginCommand.of(
-            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
+            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin");
 
     given(
             oAuthPort.getAccessToken(
-                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
+                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -109,11 +109,11 @@ class AuthServiceTest {
     User bannedUser = userWithStatus(1L, OAuthProvider.GOOGLE, "google-123", UserStatus.BANNED);
     OAuthLoginCommand command =
         OAuthLoginCommand.of(
-            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
+            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin");
 
     given(
             oAuthPort.getAccessToken(
-                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
+                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -130,11 +130,11 @@ class AuthServiceTest {
     User withdrewUser = userWithStatus(1L, OAuthProvider.GOOGLE, "google-123", UserStatus.WITHDREW);
     OAuthLoginCommand command =
         OAuthLoginCommand.of(
-            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
+            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin");
 
     given(
             oAuthPort.getAccessToken(
-                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
+                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));

--- a/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
+++ b/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
@@ -54,12 +54,9 @@ class AuthServiceTest {
   @DisplayName("TAS-001 - 신규 유저 로그인 시 유저를 저장하고 JWT를 발급해야 한다")
   void shouldSaveUserAndIssueJwtWhenNewUserLogsIn() {
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(
-            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin");
+        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(
-            oAuthPort.getAccessToken(
-                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin"))
+    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -83,12 +80,9 @@ class AuthServiceTest {
   void shouldNotSaveUserWhenExistingUserLogsIn() {
     User existingUser = existingUser(1L, OAuthProvider.GOOGLE, "google-123");
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(
-            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin");
+        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(
-            oAuthPort.getAccessToken(
-                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin"))
+    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -108,12 +102,9 @@ class AuthServiceTest {
   void shouldThrowExceptionWhenBannedUserLogsIn() {
     User bannedUser = userWithStatus(1L, OAuthProvider.GOOGLE, "google-123", UserStatus.BANNED);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(
-            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin");
+        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(
-            oAuthPort.getAccessToken(
-                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin"))
+    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));
@@ -129,12 +120,9 @@ class AuthServiceTest {
   void shouldThrowExceptionWhenWithdrewUserLogsIn() {
     User withdrewUser = userWithStatus(1L, OAuthProvider.GOOGLE, "google-123", UserStatus.WITHDREW);
     OAuthLoginCommand command =
-        OAuthLoginCommand.of(
-            OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin");
+        OAuthLoginCommand.of(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr");
 
-    given(
-            oAuthPort.getAccessToken(
-                OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr/signin"))
+    given(oAuthPort.getAccessToken(OAuthProvider.GOOGLE, "auth-code", "code-verifier", "https://gamyeon.co.kr"))
         .willReturn("oauth-token");
     given(oAuthPort.getUserInfo(OAuthProvider.GOOGLE, "oauth-token"))
         .willReturn(mockUserInfo("google-123", "test@gmail.com", "테스터"));


### PR DESCRIPTION
## 관련 이슈
closes #

## 작업 내용
Origin 헤더는 nginx/프록시가 제거해서 서버에 도달하지 않음 → 항상 null → 항상 첫 번째 URI(http://localhost:3000/signin)로 폴백 → 모든 비-localhost 요청 실패

[변경 전] 
POST /api/v1/auth/login/{provider}
Headers: Origin: https://gamyeon.co.kr/  ← nginx가 제거해버림
Body: { authorizationCode, codeVerifier }

[변경 후] 
POST /api/v1/auth/login/{provider}
Body: { authorizationCode, codeVerifier, redirectUri: "https://gamyeon.co.kr/signin" }

참고) 
프론트엔드에서 로그인 API 호출 시 redirectUri 필드를 body에 추가해야 합니다:

// 기존
{ authorizationCode: "...", codeVerifier: "..." }

변경 후
{ authorizationCode: "...", codeVerifier: "...", redirectUri: "https://gamyeon.co.kr/signin" }

redirectUri는 OAuth 인가 요청 시 사용한 값과 반드시 동일해야 함

## 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 체크리스트
- [ ] 빌드 확인 (`./gradlew build`)
- [ ] API 응답 확인
- [ ] 레이어 규칙 준수 (domain / application / infrastructure)
