### PR TITLE
fix: 답변 동영상 s3 폴더 생성 기준 intvId로 변경

### DIFF
--- a/src/main/java/com/gamyeon/answer/adapter/out/persistence/QuestionSetLoadAdapter.java
+++ b/src/main/java/com/gamyeon/answer/adapter/out/persistence/QuestionSetLoadAdapter.java
@@ -20,6 +20,16 @@ public class QuestionSetLoadAdapter implements LoadQuestionSetPort {
   }
 
   @Override
+  public Long getIntvId(Long questionSetId) {
+    QuestionSet questionSet =
+        jpaQuestionSetRepository
+            .findById(questionSetId)
+            .orElseThrow(() -> new AnswerException(AnswerErrorCode.QUESTION_SET_NOT_FOUND));
+
+    return questionSet.getIntvId();
+  }
+
+  @Override
   public String getQuestionContent(Long questionSetId) {
 
     QuestionSet questionSet =

--- a/src/main/java/com/gamyeon/answer/application/AnswerApplicationService.java
+++ b/src/main/java/com/gamyeon/answer/application/AnswerApplicationService.java
@@ -80,9 +80,7 @@ public class AnswerApplicationService
 
     String fileKey =
         storageFileKeyGenerator.generate(
-            "answers",
-            List.of(String.valueOf(intvId)),
-            command.originalFileName());
+            "answers", List.of(String.valueOf(intvId)), command.originalFileName());
     StoragePresignedUrlResult result =
         storagePresignedUrlPort.createUploadUrl(
             new StoragePresignedUrlCommand(fileKey, command.contentType()));

--- a/src/main/java/com/gamyeon/answer/application/AnswerApplicationService.java
+++ b/src/main/java/com/gamyeon/answer/application/AnswerApplicationService.java
@@ -76,11 +76,12 @@ public class AnswerApplicationService
         command.fileSizeBytes());
     validateVideoFile(command.originalFileName(), command.contentType());
     validateFileSize(command.fileSizeBytes());
+    Long intvId = loadQuestionSetPort.getIntvId(command.questionSetId());
 
     String fileKey =
         storageFileKeyGenerator.generate(
             "answers",
-            List.of(String.valueOf(command.questionSetId()), "video"),
+            List.of(String.valueOf(intvId)),
             command.originalFileName());
     StoragePresignedUrlResult result =
         storagePresignedUrlPort.createUploadUrl(

--- a/src/main/java/com/gamyeon/answer/application/port/out/LoadQuestionSetPort.java
+++ b/src/main/java/com/gamyeon/answer/application/port/out/LoadQuestionSetPort.java
@@ -4,5 +4,7 @@ public interface LoadQuestionSetPort {
 
   boolean existsById(Long questionSetId);
 
+  Long getIntvId(Long questionSetId);
+
   String getQuestionContent(Long questionSetId);
 }


### PR DESCRIPTION
## 관련 이슈
closes #31 

## 작업 내용
답변 동영상이 s3 버키셍 저장될 때의 폴더 생성 기준을 intvId로 변경합니다.

## 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타

## 체크리스트
- [x] 빌드 확인 (`./gradlew build`)
- [ ] API 응답 확인
- [x] 레이어 규칙 준수 (domain / application / infrastructure)
