### PR TITLE
fix: reissue/logout @Transactional 누락으로 인한 500 에러 수정

### DIFF
--- a/src/main/java/com/gamyeon/user/application/port/outbound/RefreshTokenRepository.java
+++ b/src/main/java/com/gamyeon/user/application/port/outbound/RefreshTokenRepository.java
@@ -1,6 +1,7 @@
 package com.gamyeon.user.application.port.outbound;
 
 import com.gamyeon.user.domain.RefreshToken;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface RefreshTokenRepository {
@@ -10,4 +11,7 @@ public interface RefreshTokenRepository {
   Optional<RefreshToken> findByToken(String token);
 
   void deleteByUserId(Long userId);
+
+  /** threshold 이전에 만료된 토큰을 일괄 삭제한다. 삭제된 건수를 반환한다. */
+  int deleteAllExpiredBefore(LocalDateTime threshold);
 }

--- a/src/main/java/com/gamyeon/user/application/service/AuthService.java
+++ b/src/main/java/com/gamyeon/user/application/service/AuthService.java
@@ -15,6 +15,7 @@ import com.gamyeon.user.domain.RefreshToken;
 import com.gamyeon.user.domain.User;
 import com.gamyeon.user.domain.UserDomainException;
 import com.gamyeon.user.domain.UserErrorCode;
+import org.springframework.transaction.annotation.Transactional;
 
 public class AuthService implements AuthUseCase {
 
@@ -64,14 +65,17 @@ public class AuthService implements AuthUseCase {
     return issueTokens(user);
   }
 
+  @Transactional
   public LoginResult reissue(String refreshTokenValue) {
     RefreshToken refreshToken =
         refreshTokenRepository
             .findByToken(refreshTokenValue)
             .orElseThrow(() -> new CommonException(CommonErrorCode.EXPIRED_TOKEN));
 
+    // 만료된 경우: 예외만 던짐 (delete는 하지 않음)
+    // - @Transactional 내에서 RuntimeException 발생 시 rollback되므로 delete가 무의미
+    // - 만료 토큰 정리는 스케줄러에 위임
     if (refreshToken.isExpired()) {
-      refreshTokenRepository.deleteByUserId(refreshToken.getUserId());
       throw new CommonException(CommonErrorCode.EXPIRED_TOKEN);
     }
 
@@ -82,10 +86,13 @@ public class AuthService implements AuthUseCase {
 
     ensureLoginAllowed(user);
 
+    // deleteByUserId + save가 하나의 트랜잭션으로 묶임
+    // → save 실패 시 delete도 함께 rollback → 기존 토큰 보존, 500 방지
     refreshTokenRepository.deleteByUserId(user.getId());
     return issueTokens(user);
   }
 
+  @Transactional
   public void logout(Long userId) {
     refreshTokenRepository.deleteByUserId(userId);
   }

--- a/src/main/java/com/gamyeon/user/infrastructure/persistence/RefreshTokenJpaRepository.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/persistence/RefreshTokenJpaRepository.java
@@ -1,12 +1,20 @@
 package com.gamyeon.user.infrastructure.persistence;
 
 import com.gamyeon.user.domain.RefreshToken;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 interface RefreshTokenJpaRepository extends JpaRepository<RefreshToken, Long> {
 
   Optional<RefreshToken> findByToken(String token);
 
   void deleteByUserId(Long userId);
+
+  @Modifying
+  @Query("DELETE FROM RefreshToken r WHERE r.expiresAt < :threshold")
+  int deleteAllExpiredBefore(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/com/gamyeon/user/infrastructure/persistence/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/persistence/RefreshTokenRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.gamyeon.user.infrastructure.persistence;
 
 import com.gamyeon.user.application.port.outbound.RefreshTokenRepository;
 import com.gamyeon.user.domain.RefreshToken;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
@@ -27,5 +28,10 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
   @Override
   public void deleteByUserId(Long userId) {
     jpaRepository.deleteByUserId(userId);
+  }
+
+  @Override
+  public int deleteAllExpiredBefore(LocalDateTime threshold) {
+    return jpaRepository.deleteAllExpiredBefore(threshold);
   }
 }

--- a/src/main/java/com/gamyeon/user/infrastructure/scheduler/RefreshTokenCleanupScheduler.java
+++ b/src/main/java/com/gamyeon/user/infrastructure/scheduler/RefreshTokenCleanupScheduler.java
@@ -1,0 +1,39 @@
+package com.gamyeon.user.infrastructure.scheduler;
+
+import com.gamyeon.user.application.port.outbound.RefreshTokenRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenCleanupScheduler {
+
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  /**
+   * 만료된 refresh token을 주기적으로 정리한다.
+   *
+   * <p>기본 주기: 매일 새벽 3시 (cron = "0 0 3 * * *")
+   *
+   * <p>application.yml 에서 {@code jwt.refresh-token-cleanup.cron} 으로 변경 가능하다.
+   */
+  @Scheduled(cron = "${jwt.refresh-token-cleanup.cron:0 0 3 * * *}")
+  @Transactional
+  public void deleteExpiredTokens() {
+    LocalDateTime now = LocalDateTime.now();
+    log.info("[RefreshToken] 만료 토큰 정리 시작 - 기준 시각: {}", now);
+
+    int deleted = refreshTokenRepository.deleteAllExpiredBefore(now);
+
+    if (deleted > 0) {
+      log.info("[RefreshToken] 만료 토큰 정리 완료 - 삭제 건수: {}건", deleted);
+    } else {
+      log.debug("[RefreshToken] 만료 토큰 정리 - 삭제 대상 없음");
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,6 +59,8 @@ cloud:
 jwt:
   access-token-expiry: 3600000
   refresh-token-expiry: 604800000
+  refresh-token-cleanup:
+    cron: "0 0 3 * * *"   # 매일 새벽 3시 만료 토큰 정리
 
 ai:
   server:

--- a/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
+++ b/src/test/java/com/gamyeon/user/application/service/AuthServiceTest.java
@@ -199,7 +199,8 @@ class AuthServiceTest {
 
     assertEquals(
         CommonErrorCode.EXPIRED_TOKEN, exception.getErrorCode(), "EXPIRED_TOKEN 에러코드로 응답해야 합니다");
-    verify(refreshTokenRepository).deleteByUserId(1L);
+    // 만료 토큰 삭제는 스케줄러에 위임 → reissue() 내에서 deleteByUserId 호출하지 않음
+    verify(refreshTokenRepository, never()).deleteByUserId(any());
   }
 
   // ── logout ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 관련 이슈
closes #

## 작업 내용
[AS IS]
- reissue(), logout() 메서드에 @Transactional 없음
- deleteByUserId()가 트랜잭션 컨텍스트 없이 호출되어 em.remove() 실행 시 TransactionRequiredException 발생 → 500 에러
- reissue() 에서 deleteByUserId(delete)와 issueTokens()(save)가 별개 트랜잭션으로 실행되어 비원자적 처리
- delete 성공 후 save 실패 시 기존 토큰 영구 삭제 → 사용자 재로그인 강제
- 만료 토큰 처리 시 deleteByUserId 후 예외 throw → @Transactional 적용 시 delete가 rollback되어 삭제 무효화

[TO BE]
- reissue(), logout()에 @Transactional 추가 → deleteByUserId()에 트랜잭션 컨텍스트 제공, 500 해결
- reissue() 내 deleteByUserId + save가 단일 트랜잭션으로 처리 → save 실패 시 delete 함께 rollback, 토큰 보존
- 만료 토큰 처리 시 deleteByUserId 제거, 예외만 throw → 만료 토큰 정리는 별도 스케줄러에 위임 
- 토큰 정리 스케줄러는 유동적(기본 매일 새벽 3시 작동)

## 변경 사항
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 체크리스트
- [ ] 빌드 확인 (`./gradlew build`)
- [ ] API 응답 확인
- [ ] 레이어 규칙 준수 (domain / application / infrastructure)
