### PR TITLE
fix: 카카오 로그인 닉네임 폴백 문제 수정

### DIFF
--- a/src/main/java/com/gamyeon/user/application/service/NicknameResolver.java
+++ b/src/main/java/com/gamyeon/user/application/service/NicknameResolver.java
@@ -1,17 +1,33 @@
 package com.gamyeon.user.application.service;
 
-import java.util.regex.Pattern;
-
 public class NicknameResolver {
 
-  private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9]{1,8}$");
   private static final int MAX_NICKNAME_LENGTH = 8;
 
+  /**
+   * OAuth 제공자 닉네임을 정제하여 반환한다.
+   *
+   * <p>불허 문자(공백·특수문자 등)는 제거하고, 8자를 초과하면 잘라낸다. 정제 후 비어있으면 이메일 localPart로 대체한다.
+   *
+   * <p>허용 문자: 한글(가-힣), 영문(a-z, A-Z), 숫자(0-9), 언더스코어(_)
+   */
   public String resolve(String providerNickname, String email) {
-    if (providerNickname != null && NICKNAME_PATTERN.matcher(providerNickname).matches()) {
-      return providerNickname;
+    if (providerNickname != null && !providerNickname.isBlank()) {
+      String sanitized = sanitize(providerNickname);
+      if (!sanitized.isEmpty()) {
+        return sanitized;
+      }
     }
     return extractFromEmail(email);
+  }
+
+  private String sanitize(String nickname) {
+    // 허용 문자 이외 제거 후 최대 길이 truncate
+    String cleaned = nickname.replaceAll("[^가-힣a-zA-Z0-9_]", "");
+    if (cleaned.length() > MAX_NICKNAME_LENGTH) {
+      cleaned = cleaned.substring(0, MAX_NICKNAME_LENGTH);
+    }
+    return cleaned;
   }
 
   private String extractFromEmail(String email) {
@@ -19,8 +35,10 @@ public class NicknameResolver {
       return "user" + (int) (Math.random() * 100000);
     }
     String localPart = email.contains("@") ? email.split("@")[0] : email;
-    if (localPart.length() > MAX_NICKNAME_LENGTH) {
-      localPart = localPart.substring(0, MAX_NICKNAME_LENGTH);
+    // 이메일 localPart도 동일 규칙으로 정제
+    localPart = sanitize(localPart);
+    if (localPart.isEmpty()) {
+      return "user" + (int) (Math.random() * 100000);
     }
     return localPart;
   }


### PR DESCRIPTION
## 관련 이슈
closes #

## 작업 내용
[AS IS]
- NicknameResolver가 정규식(^[가-힣a-zA-Z0-9]{1,8}$)에 완전 일치하지 않으면 닉네임 전체를 폐기
- 공백 포함("홍 길동"), 언더스코어 포함("user_name"), 8자 초과 닉네임 모두 이메일 localPart로 폴백
- 카카오 닉네임이 사실상 무시되어 "kakao_48" 형태의 이메일 기반 닉네임이 저장됨

[TO BE]
- 불허 문자(공백·특수문자 등)를 제거한 뒤 남은 문자로 닉네임 구성 (폐기 대신 정제 후 사용)
- 8자 초과 시 앞 8자로 truncate하여 사용
- 허용 문자: 한글(가-힣), 영문(a-z, A-Z), 숫자(0-9), 언더스코어(_)
- 정제 후 빈 문자열이 되는 경우에만 이메일 localPart로 폴백
- 이메일 localPart도 동일 sanitize 규칙 적용

[Frontend]
- 카카오 인가 요청 URL에 scope 파라미터 명시 필요 scope=profile_nickname,account_email
- JS SDK 사용 시: Kakao.Auth.authorize({ scope: 'profile_nickname,account_email' })
- 주의: 기존에 scope 없이 로그인한 유저는 앱 연결 해제 후 재로그인해야 닉네임 정상 수신
   -> 해당 문제에 대해 데이터베이스 마이그레이션 OR 데이터 삭제 후 시도

## 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타

## 체크리스트
- [x] 빌드 확인 (`./gradlew build`)
- [ ] API 응답 확인
- [x] 레이어 규칙 준수 (domain / application / infrastructure)
