### PR TITLE
Fix/get report detail

### DIFF
--- a/src/main/java/com/gamyeon/report/application/exception/ReportAccessDeniedException.java
+++ b/src/main/java/com/gamyeon/report/application/exception/ReportAccessDeniedException.java
@@ -1,0 +1,20 @@
+package com.gamyeon.report.application.exception;
+
+// ReportNotFoundException의 부모 클래스와 동일하게 맞춰주세요 (예: CustomException, BusinessException 등)
+public class ReportAccessDeniedException extends RuntimeException {
+
+    private final Long intvId;
+
+    public ReportAccessDeniedException(Long intvId) {
+        super(ReportErrorCode.REPORT_ACCESS_DENIED.getMessage());
+        this.intvId = intvId;
+    }
+
+    public Long getIntvId() {
+        return intvId;
+    }
+
+    public ReportErrorCode getErrorCode() {
+        return ReportErrorCode.REPORT_ACCESS_DENIED;
+    }
+}

--- a/src/main/java/com/gamyeon/report/application/exception/ReportErrorCode.java
+++ b/src/main/java/com/gamyeon/report/application/exception/ReportErrorCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ReportErrorCode implements ErrorCode {
   REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "리포트를 찾을 수 없습니다.", "RPRT-N001"),
+  REPORT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 리포트에 접근할 권한이 없습니다.", "RPRT-F001"),
   REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 리포트가 생성된 세션입니다.", "RPRT-B002"),
   REPORT_GENERATION_CONDITION_NOT_MET(
       HttpStatus.BAD_REQUEST, "리포트 생성 조건이 충족되지 않았습니다.", "RPRT-B001"),

--- a/src/main/java/com/gamyeon/report/application/port/in/GetReportDetailUseCase.java
+++ b/src/main/java/com/gamyeon/report/application/port/in/GetReportDetailUseCase.java
@@ -5,5 +5,8 @@ import com.gamyeon.report.infrastructure.web.dto.ReportDetailResponse;
 public interface GetReportDetailUseCase {
 
   /** 리포트 상세 조회 - REPORTS.report_data(jsonb) 파싱 후 반환 - 리포트 없음 → RPRT-N001 */
+  /*
+  * 타 사용자의 리포트 조회 시도시에도 리포트 없음으로 반환
+  */
   ReportDetailResponse getDetail(Long intvId, Long userId);
 }

--- a/src/main/java/com/gamyeon/report/application/port/in/GetReportDetailUseCase.java
+++ b/src/main/java/com/gamyeon/report/application/port/in/GetReportDetailUseCase.java
@@ -6,7 +6,7 @@ public interface GetReportDetailUseCase {
 
   /** 리포트 상세 조회 - REPORTS.report_data(jsonb) 파싱 후 반환 - 리포트 없음 → RPRT-N001 */
   /*
-  * 타 사용자의 리포트 조회 시도시에도 리포트 없음으로 반환
-  */
+   * 타 사용자의 리포트 조회 시도시에도 리포트 없음으로 반환
+   */
   ReportDetailResponse getDetail(Long intvId, Long userId);
 }

--- a/src/main/java/com/gamyeon/report/application/service/ReportQueryService.java
+++ b/src/main/java/com/gamyeon/report/application/service/ReportQueryService.java
@@ -40,6 +40,8 @@ public class ReportQueryService implements GetReportDetailUseCase, DeleteReportU
         loadReportPort.findByIntvId(intvId).orElseThrow(() -> new ReportNotFoundException(intvId));
 
     if (!report.getUserId().equals(userId)) {
+      log.warn("[Report] 권한 없는 접근 시도 - intvId={}, requestUserId={}, ownerUserId={}",
+              intvId, userId, report.getUserId());
       throw new ReportNotFoundException(intvId);
     }
 

--- a/src/main/java/com/gamyeon/report/application/service/ReportQueryService.java
+++ b/src/main/java/com/gamyeon/report/application/service/ReportQueryService.java
@@ -29,16 +29,22 @@ public class ReportQueryService implements GetReportDetailUseCase, DeleteReportU
   private final LoadAnswerPort loadAnswerPort;
 
   // ── 상세 조회 ──────────────────────────────────────────────────────────────
-
+  /*
+   * 타 사용자의 리포트 조회 시도시, 404 반환
+   *
+   */
   @Override
   @Transactional(readOnly = true)
   public ReportDetailResponse getDetail(Long intvId, Long userId) {
     Report report =
         loadReportPort.findByIntvId(intvId).orElseThrow(() -> new ReportNotFoundException(intvId));
 
+    if (!report.getUserId().equals(userId)) {
+      throw new ReportNotFoundException(intvId);
+    }
+
     Intv intv = loadIntvPort.findById(intvId).orElse(null);
     List<Answer> answers = loadAnswerPort.findByIntvIdOrderByAnswerOrder(intvId);
-
     return ReportDetailResponse.builder()
         .intvId(intvId)
         .intvStatus(intv != null ? intv.getStatus().name() : null)

--- a/src/main/java/com/gamyeon/report/application/service/ReportQueryService.java
+++ b/src/main/java/com/gamyeon/report/application/service/ReportQueryService.java
@@ -2,6 +2,7 @@ package com.gamyeon.report.application.service;
 
 import com.gamyeon.answer.domain.Answer;
 import com.gamyeon.intv.domain.Intv;
+import com.gamyeon.report.application.exception.ReportAccessDeniedException;
 import com.gamyeon.report.application.exception.ReportNotFoundException;
 import com.gamyeon.report.application.port.in.DeleteReportUseCase;
 import com.gamyeon.report.application.port.in.GetReportDetailUseCase;
@@ -30,45 +31,50 @@ public class ReportQueryService implements GetReportDetailUseCase, DeleteReportU
 
   // ── 상세 조회 ──────────────────────────────────────────────────────────────
   /*
-   * 타 사용자의 리포트 조회 시도시, 404 반환
-   *
+   * 리포트가 존재하지 않거나, 타 사용자 소유인 경우 모두 403 반환
+   * (존재 여부 노출 방지를 위해 두 케이스를 동일하게 처리)
    */
   @Override
   @Transactional(readOnly = true)
   public ReportDetailResponse getDetail(Long intvId, Long userId) {
-    Report report =
-        loadReportPort.findByIntvId(intvId).orElseThrow(() -> new ReportNotFoundException(intvId));
+    Report report = loadReportPort.findByIntvId(intvId).orElse(null);
 
-    if (!report.getUserId().equals(userId)) {
+    if (report == null || !report.getUserId().equals(userId)) {
       log.warn(
-          "[Report] 권한 없는 접근 시도 - intvId={}, requestUserId={}, ownerUserId={}",
-          intvId,
-          userId,
-          report.getUserId());
-      throw new ReportNotFoundException(intvId);
+              "[Report] 권한 없는 접근 시도 - intvId={}, requestUserId={}, ownerUserId={}",
+              intvId,
+              userId,
+              report != null ? report.getUserId() : null);
+      throw new ReportAccessDeniedException(intvId);
     }
 
     Intv intv = loadIntvPort.findById(intvId).orElse(null);
     List<Answer> answers = loadAnswerPort.findByIntvIdOrderByAnswerOrder(intvId);
     return ReportDetailResponse.builder()
-        .intvId(intvId)
-        .intvStatus(intv != null ? intv.getStatus().name() : null)
-        .reportStatus(report.getStatus().name())
-        .report(
-            report.getStatus().name().equals("SUCCEED") ? parseReportData(report, answers) : null)
-        .build();
+            .intvId(intvId)
+            .intvStatus(intv != null ? intv.getStatus().name() : null)
+            .reportStatus(report.getStatus().name())
+            .report(
+                    report.getStatus().name().equals("SUCCEED") ? parseReportData(report, answers) : null)
+            .build();
   }
 
   // ── 삭제 ──────────────────────────────────────────────────────────────────
-
+  /*
+   * 리포트가 존재하지 않거나, 타 사용자 소유인 경우 모두 403 반환
+   */
   @Override
   @Transactional
   public void delete(Long intvId, Long userId) {
-    Report report =
-        loadReportPort.findByIntvId(intvId).orElseThrow(() -> new ReportNotFoundException(intvId));
+    Report report = loadReportPort.findByIntvId(intvId).orElse(null);
 
-    if (!report.getUserId().equals(userId)) {
-      throw new ReportNotFoundException(intvId);
+    if (report == null || !report.getUserId().equals(userId)) {
+      log.warn(
+              "[Report] 권한 없는 삭제 시도 - intvId={}, requestUserId={}, ownerUserId={}",
+              intvId,
+              userId,
+              report != null ? report.getUserId() : null);
+      throw new ReportAccessDeniedException(intvId);
     }
 
     saveReportPort.delete(report);

--- a/src/main/java/com/gamyeon/report/application/service/ReportQueryService.java
+++ b/src/main/java/com/gamyeon/report/application/service/ReportQueryService.java
@@ -40,8 +40,11 @@ public class ReportQueryService implements GetReportDetailUseCase, DeleteReportU
         loadReportPort.findByIntvId(intvId).orElseThrow(() -> new ReportNotFoundException(intvId));
 
     if (!report.getUserId().equals(userId)) {
-      log.warn("[Report] 권한 없는 접근 시도 - intvId={}, requestUserId={}, ownerUserId={}",
-              intvId, userId, report.getUserId());
+      log.warn(
+          "[Report] 권한 없는 접근 시도 - intvId={}, requestUserId={}, ownerUserId={}",
+          intvId,
+          userId,
+          report.getUserId());
       throw new ReportNotFoundException(intvId);
     }
 


### PR DESCRIPTION
## 관련 이슈
closes #36 

## 작업 내용
- 타인 리포트 조회 가능 내용 방지 
서비스 코드에 사용자 검증로직 추가했습니다. 

이어서 리포트  목록(인터뷰목록,getIntvs), 대시보드(intv/stats) 에는 문제가 없음을 확인했습니다. 

### 관련 정책
403에러는 존재 유무를 알 수도 있어서 타인의 면접기록 조회하는 것을 시도할때, 404에러를 반환하는 형식으로 구현했습니다. 

403 - Forbidden (금지) 
404 - Not Found (아예 없음)
## 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 체크리스트
- [ ] 빌드 확인 (`./gradlew build`)
- [ ] API 응답 확인
- [ ] 레이어 규칙 준수 (domain / application / infrastructure)
